### PR TITLE
Update for server 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ with WinRM. Please, refer to Ansible documentation:
 - [Setting up a Windows Host](https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html)
 - [Windows Remote Management](https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html)
 
+The account used to connect to the Windows virtual machine must have permissions to run the script with administrator permissions.
+
 Role Variables
 --------------
 
@@ -45,3 +47,19 @@ configured and will try to install the agent.
   roles:
     - role: fdupont_redhat.ims_premigration_windows
 ```
+
+Pre-Migration Script and virt-v2v First Boot
+------------------------------
+
+This section provides a primer on how the script is used as part of the migration process.
+
+The pre-migration script `pre-migrate.ps1` captures
+information about the VMs network and disk configuration and generates a powershell script to reapply the configuration after migration to OCP. The generated script is written to following path on the VM's system drive `\Program Files\Guestfs\Firstboot\scripts\`.
+
+After the VM has been migrated to OCP virt-v2v runs a series of tasks as part of a process called `first boot`. Part of process is executing scripts stored in above mentioned scripts directory.
+
+Post migration hooks are not required for scripts run as part of the first boot process.
+
+**NOTE:** The first boot directory path is hard coded in virt-v2v, do not change the script paths in the PowerShell file.
+
+**NOTE:** The pre-migration script makes no configuration changes to the VM, only the generated script makes configuration changes.


### PR DESCRIPTION
Changes to script based on testing with Windows Server 2016 and Windows 10.

- Update Readme to provide additional clarity about how the script and first boot function
- Update to version 1.1
- Line 91: Resolve error: msft_netipaddress already exists
- Line 129: Correct expression for drives with no drive letter
- Line 148 - Line 164: Change to `get-wmiobject` for consistency with following lines and refactor
- Line 149: Add device type to filter out drivers other than local disk
- Lines 153 - 155: Filter out system drive from drive letter assignment as driver is assigned by default